### PR TITLE
make Ethernet.h WiFi101.h compatible

### DIFF
--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -12,7 +12,8 @@
 
 #include <SPI.h>
 
-typedef uint8_t SOCKET;
+typedef signed char sint8;
+typedef sint8 SOCKET;
 
 //#define W5100_ETHERNET_SHIELD // Arduino Ethenret Shield and Compatibles ...
 //#define W5200_ETHERNET_SHIELD // WIZ820io, W5200 Ethernet Shield 


### PR DESCRIPTION
so they can be included in the same sketch, needed for senseBox_Library

after a quick test, DHCP & EthernetClient are still working. however, we should test more with default senseBox:home sketch before merge